### PR TITLE
Expose a hide on click function

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,15 @@ the possible combinations of [position] and [alignment].
 
 Whether or not to hide the popover when it is clicked on, default: ``true``.
 
+### Programmatic Hiding of the Popover
 
+Register the ``hidePopover()`` function against a ``ng-click`` directive to hide the popover when a specific element is clicked (e.g. a close button):
+
+```html
+<button ng-click="hidePopover()">Close</button>
+```
+
+This button lives within the popover template.
 
 ### Themes
 

--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -103,6 +103,10 @@
             $popover.remove();
           });
 
+          scope.hidePopover = function() {
+            hider_.hide($popover, 0);
+          };
+
           $popover
             .css('position', 'absolute')
             .css('display', 'none');


### PR DESCRIPTION
This allows for element-targeted closing of the popover (e.g. via a close button within the popover template).
