### PR TITLE
Isolate popover directive scope

### DIFF
--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -11,6 +11,7 @@
   module.directive('nsPopover', function($timeout, $templateCache, $q, $http, $compile, $document) {
     return {
       restrict: 'A',
+      scope: true,
       link: function(scope, elm, attrs) {
         var options = {
           template: attrs.nsPopoverTemplate,


### PR DESCRIPTION
Previously, if multiple popovers were added, they would all share the
same scope.

I encountered an issue when trying to add several popovers, each with a
"close" link that specifying `ng-click="hidePopover()"`. Since all
popovers share scope, the `hidePopover()` function only knows about the
last popover it saw. This means that only that last popover can be
hidden using `hidePopover()`.

This change ensures that all popovers have their own scope, so
`hidePopover()` will now operate on the correct instance.

Fixes #11.

Demos (try clicking the “Close” link inside popovers):
- Before patch: http://plnkr.co/edit/R53RPA7EdRkiU9NvB1D9?p=preview
- After patch: http://plnkr.co/edit/QpPzcBDm0OBMdUejFGpv?p=preview
