### PR TITLE
List dependencies as strings.

### DIFF
--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -8,7 +8,7 @@
   var $popovers = [];
   var globalId = 0;
 
-  module.directive('nsPopover', function($timeout, $templateCache, $q, $http, $compile, $document) {
+  module.directive('nsPopover', ["$timeout", "$templateCache", "$q", "$http", "$compile", "$document", function($timeout, $templateCache, $q, $http, $compile, $document) {
     return {
       restrict: 'A',
       scope: true,
@@ -288,5 +288,5 @@
         }
       }
     };
-  });
+  }]);
 })(window, window.angular);


### PR DESCRIPTION
When minifying the script, the dependencies need to be listed as strings.
Also see here: see https://docs.angularjs.org/tutorial/step_05
