### PR TITLE
use a provider to set some default configuration to all of our popover

### DIFF
--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -8,22 +8,52 @@
   var $popovers = [];
   var globalId = 0;
 
-  module.directive('nsPopover', ["$timeout", "$templateCache", "$q", "$http", "$compile", "$document", function($timeout, $templateCache, $q, $http, $compile, $document) {
+  module.provider('nsPopover', function () {
+    var defaults = {
+      template: '',
+      theme: 'ns-popover-list-theme',
+      plain: false,
+      trigger: 'click',
+      container: 'body',
+      placement: 'bottom|left',
+      timeout: 1.5,
+      hideOnClick: true,
+      mouserelative_x: false,
+      mouserelative_y: false
+    };
+
+    this.setDefaults = function (newDefaults) {
+      angular.extend(defaults, newDefaults);
+    };
+
+    this.$get = [
+      function () {
+        return {
+          getDefaults: function () {
+            return defaults;
+          }
+        };
+      }];
+  });
+
+  module.directive('nsPopover', ["nsPopover", "$timeout", "$templateCache", "$q", "$http", "$compile", "$document", function(nsPopover, $timeout, $templateCache, $q, $http, $compile, $document) {
     return {
       restrict: 'A',
       scope: true,
       link: function(scope, elm, attrs) {
+        var defaults = nsPopover.getDefaults();
+
         var options = {
-          template: attrs.nsPopoverTemplate,
-          theme: attrs.nsPopoverTheme || 'ns-popover-list-theme',
-          plain: attrs.nsPopoverPlain,
-          trigger: attrs.nsPopoverTrigger || 'click',
-          container: attrs.nsPopoverContainer,
-          placement: attrs.nsPopoverPlacement || 'bottom|left',
-          timeout: attrs.nsPopoverTimeout || 1.5,
-          hideOnClick: attrs.nsPopoverHideOnClick === 'true' || attrs.nsPopoverHideOnClick === undefined,
-		  mouserelative_x: attrs.nsPopoverMouseRelative === 'x' || attrs.nsPopoverMouseRelative === 'xy',
-		  mouserelative_y: attrs.nsPopoverMouseRelative === 'y' || attrs.nsPopoverMouseRelative === 'xy'
+          template: attrs.nsPopoverTemplate || defaults.template,
+          theme: attrs.nsPopoverTheme || defaults.theme,
+          plain: attrs.nsPopoverPlain || defaults.plain,
+          trigger: attrs.nsPopoverTrigger || defaults.trigger,
+          container: attrs.nsPopoverContainer || defaults.container,
+          placement: attrs.nsPopoverPlacement || defaults.placement ,
+          timeout: attrs.nsPopoverTimeout || defaults.timeout,
+          hideOnClick: attrs.nsPopoverHideOnClick === 'true' || attrs.nsPopoverHideOnClick === undefined || defaults.hideOnClick,
+    		  mouserelative_x: attrs.nsPopoverMouseRelative === 'x' || attrs.nsPopoverMouseRelative === 'xy' || defaults.mouserelative_x,
+    		  mouserelative_y: attrs.nsPopoverMouseRelative === 'y' || attrs.nsPopoverMouseRelative === 'xy' || defaults.mouserelative_y
         };
 
         var hider_ = {


### PR DESCRIPTION
For a projet I'm working on, I have to use a lot of popover directive who are almost the same, so it become annoying to have to add the same attributes every time. So I modify the directive to be able to set some default configuration for all my project.

I simply create a `setDefaults` method in a provider for the `nsPopover`, to use it, I simply have to add a config on my project like this : 

```
angular.module('myApp', []).config([
  'nsPopoverProvider',
  function (nsPopoverProvider) {
    return nsPopoverProvider.setDefaults({
      theme: 'ns-popover-tooltip-theme',
      plain: true,
      trigger: 'mouseenter',
      placement: 'bottom',
      timeout: 0
    });
  }
]);
```

we only set the options we want to change, all of them got a default value.
