### PR TITLE
Focusing initiator element on close

### DIFF
--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -143,6 +143,7 @@
 
           scope.hidePopover = function() {
             hider_.hide($popover, 0);
+            elm.focus();
           };
 
           $popover


### PR DESCRIPTION
Great directive! Thank you.

I needed to keep the tabindex after the popover was closed, so I made it.
Just contributing back.

Au revoir
