### PR TITLE
Added modal option to close other popover instances 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ Locks the position relative to the mouse. The following are possible values:
  * y - Constraints the y axis to follow the mouse.
  * xy - Constraints both the x and y axis to follow the mouse.
 
+### ``ns-popover-modal {Boolean/String}``
+
+The ``ns-popover-modal`` specifies the group of popovers which should be closed when this instance is shown. This allows
+ * false - Other popovers will not be hidden (default)
+ * true - All popover instances will be hidden when this one instance is shown
+ * String - All popovers with this modal group specified will be hidden when this instance is shown
+
 ### Programmatic Hiding of the Popover
 
 Register the ``hidePopover()`` function against a ``ng-click`` directive to hide the popover when a specific element is clicked (e.g. a close button):

--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -20,7 +20,8 @@
       timeout: 1.5,
       hideOnClick: 'true',
       mouseRelative: '',
-      popupDelay: 0
+      popupDelay: 0,
+      modal: false
     };
 
     this.setDefaults = function (newDefaults) {
@@ -55,7 +56,8 @@
           timeout: attrs.nsPopoverTimeout || defaults.timeout,
           hideOnClick: toBoolean(attrs.nsPopoverHideOnClick || defaults.hideOnClick),
           mouseRelative: attrs.nsPopoverMouseRelative,
-          popupDelay: attrs.nsPopoverPopupDelay || defaults.popupDelay
+          popupDelay: attrs.nsPopoverPopupDelay || defaults.popupDelay,
+          modal: attrs.nsPopoverModal || defaults.modal
         };
 
         if (options.mouseRelative) {
@@ -71,6 +73,11 @@
 
             if (!isDef(delay)) {
               delay = 0;
+            }
+            
+            //hide any popovers being displayed
+            if (options.modal){
+             $rootScope.$broadcast('hidePopover', options.modal);   
             }
 
             displayer_.id_ = $timeout(function() {
@@ -186,7 +193,13 @@
           scope.hidePopover = function() {
             hider_.hide($popover, 0);
           };
-
+            
+          scope.$on('hidePopover', function(ev, modal){
+              if (options.modal === modal) {
+                scope.hidePopover()
+              }
+          });
+            
           $popover
             .css('position', 'absolute')
             .css('display', 'none');


### PR DESCRIPTION
Added an additional option to allow 'modal' like behaviour for popovers. 

Useful for cases where you have many popovers on a 'mouseover' trigger in a table for example.
You can specify a string which will only close other popovers with that modal string specified, or a boolean which is the default value.  
