### PR TITLE
Updated ns-popover-placement documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ triggered by the popover.
 ### ``ns-popover-placement {String}``
 
 Specifies how to position the popover relative to the triggering element. The placement attribute has the given
-syntax: [position] [alignment]. The [position] parameter specifies the position - top, left, right, position - of
-the popover, and the alignment defines the alignment of the popover - center, left, right. The list above shows
+syntax: [position]|[alignment]. The [position] parameter specifies the position (top/right/bottom/left) of
+the popover, and the alignment defines the alignment of the popover (left/center/right). The list below shows
 the possible combinations of [position] and [alignment].
 
 Position | Alignment | Description


### PR DESCRIPTION
The syntax for the [position] and [alignment] values of the ns-popover-placement attribute were incorrect in the README. Just made some minor updates to show the correct "[position]|[alignment]" syntax.