### PR TITLE
Reorganize and clean up the syntax for easier readability.

### DIFF
--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -1,30 +1,30 @@
 (function(window, angular, undefined){
   'use strict';
 
-  var module = angular.module('nsPopover', []);
   var $el = angular.element;
-  var isDef = angular.isDefined;
   var $popovers = [];
   var globalId = 0;
+  var isDef = angular.isDefined;
+  var module = angular.module('nsPopover', []);
 
   module.provider('nsPopover', function () {
     var defaults = {
-      template: '',
-      theme: 'ns-popover-list-theme',
-      plain: 'false',
-      trigger: 'click',
-      triggerPrevent: true,
-      angularEvent: '',
-      scopeEvent: '',
+      angularEvent: null,
       container: 'body',
-      placement: 'bottom|left',
-      timeout: 1.5,
+      hideOnButtonClick: true,
       hideOnInsideClick: false,
       hideOnOutsideClick: true,
-      hideOnButtonClick: true,
       mouseRelative: '',
+      placement: 'bottom|left',
+      plain: 'false',
       popupDelay: 0,
       restrictBounds: false,
+      scopeEvent: null,
+      template: '',
+      theme: 'ns-popover-list-theme',
+      timeout: 1.5,
+      trigger: 'click',
+      triggerPrevent: true,
     };
 
     this.setDefaults = function(newDefaults) {
@@ -40,243 +40,196 @@
     };
   });
 
-  module.directive('nsPopover', ['nsPopover','$rootScope','$timeout','$templateCache','$q','$http','$compile','$document','$parse',
-    function(nsPopover, $rootScope, $timeout, $templateCache, $q, $http, $compile, $document, $parse) {
+  module.directive('nsPopover', [
+    'nsPopover',
+    '$rootScope',
+    '$timeout',
+    '$templateCache',
+    '$q',
+    '$http',
+    '$compile',
+    '$document',
+    '$parse',
+    function(
+      nsPopover,
+      $rootScope,
+      $timeout,
+      $templateCache,
+      $q,
+      $http,
+      $compile,
+      $document,
+      $parse
+    ) {
       return {
         restrict: 'A',
         scope: true,
         link: function(scope, elm, attrs) {
+          var $container;
+          var $popover;
+          var $triangle;
+          var align_;
           var defaults = nsPopover.getDefaults();
-
+          var displayer_;
+          var hider_;
+          var match;
           var options = {
-            template: attrs.nsPopoverTemplate || defaults.template,
-            theme: attrs.nsPopoverTheme || defaults.theme,
-            plain: toBoolean(attrs.nsPopoverPlain || defaults.plain),
-            trigger: attrs.nsPopoverTrigger || defaults.trigger,
-            triggerPrevent: attrs.nsPopoverTriggerPrevent || defaults.triggerPrevent,
             angularEvent: attrs.nsPopoverAngularEvent || defaults.angularEvent,
-            scopeEvent: attrs.nsPopoverScopeEvent || defaults.scopeEvent,
             container: attrs.nsPopoverContainer || defaults.container,
-            placement: attrs.nsPopoverPlacement || defaults.placement,
-            timeout: attrs.nsPopoverTimeout || defaults.timeout,
+            group: attrs.nsPopoverGroup,
+            hideOnButtonClick: toBoolean(attrs.nsPopoverHideOnButtonClick || defaults.hideOnButtonClick),
             hideOnInsideClick: toBoolean(attrs.nsPopoverHideOnInsideClick || defaults.hideOnInsideClick),
             hideOnOutsideClick: toBoolean(attrs.nsPopoverHideOnOutsideClick || defaults.hideOnOutsideClick),
-            hideOnButtonClick: toBoolean(attrs.nsPopoverHideOnButtonClick || defaults.hideOnButtonClick),
             mouseRelative: attrs.nsPopoverMouseRelative,
+            placement: attrs.nsPopoverPlacement || defaults.placement,
+            plain: toBoolean(attrs.nsPopoverPlain || defaults.plain),
             popupDelay: attrs.nsPopoverPopupDelay || defaults.popupDelay,
-            group: attrs.nsPopoverGroup,
             restrictBounds: Boolean(attrs.nsPopoverRestrictBounds) || defaults.restrictBounds,
+            scopeEvent: attrs.nsPopoverScopeEvent || defaults.scopeEvent,
+            template: attrs.nsPopoverTemplate || defaults.template,
+            theme: attrs.nsPopoverTheme || defaults.theme,
+            timeout: attrs.nsPopoverTimeout || defaults.timeout,
+            trigger: attrs.nsPopoverTrigger || defaults.trigger,
+            triggerPrevent: attrs.nsPopoverTriggerPrevent || defaults.triggerPrevent,
           };
+          var placement_;
+          var unregisterActivePopoverListeners;
+          var unregisterDisplayMethod;
 
           if (options.mouseRelative) {
             options.mouseRelativeX = options.mouseRelative.indexOf('x') !== -1;
             options.mouseRelativeY = options.mouseRelative.indexOf('y') !== -1;
           }
 
-          var displayer_ = {
-            id_: undefined,
-
-            /**
-             * Set the display property of the popover to 'block' after |delay| milliseconds.
-             *
-             * @param delay {Number}  The time (in seconds) to wait before set the display property.
-             * @param e {Event}  The event which caused the popover to be shown.
-             */
-            display: function(delay, e) {
-              // Disable popover if ns-popover value is false
-              if ($parse(attrs.nsPopover)(scope) === false) {
-                return;
-              }
-
-              $timeout.cancel(displayer_.id_);
-
-              if (!isDef(delay)) {
-                delay = 0;
-              }
-
-              // hide any popovers being displayed
-              if (options.group) {
-                $rootScope.$broadcast('ns:popover:hide', options.group);
-              }
-
-              displayer_.id_ = $timeout(function() {
-                $popover.isOpen = true;
-                $popover.css('display', 'block');
-
-                // position the popover accordingly to the defined placement around the
-                // |elm|.
-                var elmRect = getBoundingClientRect(elm[0]);
-
-                // If the mouse-relative options is specified we need to adjust the
-                // element client rect to the current mouse coordinates.
-                if (options.mouseRelative) {
-                  elmRect = adjustRect(elmRect, options.mouseRelativeX, options.mouseRelativeY, e);
-                }
-
-                move($popover, placement_, align_, elmRect, $triangle);
-
-                if (options.hideOnInsideClick) {
-                  // Hide the popover without delay on the popover click events.
-                  $popover.on('click', insideClickHandler);
-                }
-                if (options.hideOnOutsideClick) {
-                  // Hide the popover without delay on outside click events.
-                  $document.on('click', outsideClickHandler);
-                }
-                if (options.hideOnButtonClick) {
-                  // Hide the popover without delay on the button click events.
-                  elm.on('click', buttonClickHandler);
-                }
-              }, delay*1000);
-            },
-
-            cancel: function() {
-              $timeout.cancel(displayer_.id_);
-            }
-          };
-
-          var hider_ = {
-            id_: undefined,
-
-            /**
-             * Set the display property of the popover to 'none' after |delay| milliseconds.
-             *
-             * @param delay {Number}  The time (in seconds) to wait before set the display property.
-             */
-            hide: function(delay) {
-              $timeout.cancel(hider_.id_);
-
-              // do not hide if -1 is passed in.
-              if(delay !== "-1") {
-                // delay the hiding operation for 1.5s by default.
-                if (!isDef(delay)) {
-                  delay = 1.5;
-                }
-
-                hider_.id_ = $timeout(function() {
-                  $popover.off('click', insideClickHandler);
-                  $document.off('click', outsideClickHandler);
-                  elm.off('click', buttonClickHandler);
-                  $popover.isOpen = false;
-                  displayer_.cancel();
-                  $popover.css('display', 'none');
-                }, delay*1000);
-              }
-            },
-
-            cancel: function() {
-              $timeout.cancel(hider_.id_);
-            }
-          };
-
-          var $container = $document.find(options.container);
-          if (!$container.length) {
-            $container = $document.find('body');
-          }
-
-          var $triangle;
-          var placement_;
-          var align_;
-
-          globalId += 1;
-
-          var $popover = $el('<div id="nspopover-' + globalId +'"></div>');
-          $popovers.push($popover);
-
-          var match = options.placement
-            .match(/^(top|bottom|left|right)$|((top|bottom)\|(center|left|right)+)|((left|right)\|(center|top|bottom)+)/);
-
-          if (!match) {
-            throw new Error('"' + options.placement + '" is not a valid placement or has a invalid combination of placements.');
-          }
-
-          placement_ = match[6] || match[3] || match[1];
-          align_ = match[7] || match[4] || match[2] || 'center';
-
-          $q.when(loadTemplate(options.template, options.plain)).then(function(template) {
-            template = angular.isString(template) ?
-              template :
-              template.data && angular.isString(template.data) ?
-                template.data :
-                '';
-
-            $popover.html(template);
-
-            if (options.theme) {
-              $popover.addClass(options.theme);
+          function addEventListeners() {
+            function cancel() {
+              hider_.cancel();
             }
 
-            // Add classes that identifies the placement and alignment of the popver
-            // which allows the customization of the popover based on its position.
+            function hide() {
+              hider_.hide(options.timeout);
+            }
+
+            elm
+              .on('mouseout', hide)
+              .on('mouseover', cancel)
+            ;
+
             $popover
-              .addClass('ns-popover-' + placement_ + '-placement')
-              .addClass('ns-popover-' + align_ + '-align');
+              .on('mouseout', hide)
+              .on('mouseover', cancel)
+            ;
 
-            $compile($popover)(scope);
+            unregisterActivePopoverListeners = function() {
+              elm
+                .off('mouseout', hide)
+                .off('mouseover', cancel)
+              ;
 
-            scope.$on('$destroy', function() {
-              $popover.remove();
-            });
+              $popover
+                .off('mouseout', hide)
+                .off('mouseover', cancel)
+              ;
+            }
+          }
 
-            scope.hidePopover = function() {
-              hider_.hide(0);
+          /**
+           * Adjust a rect accordingly to the given x and y mouse positions.
+           *
+           * @param rect {ClientRect} The rect to be adjusted.
+           */
+          function adjustRect(rect, adjustX, adjustY, ev) {
+            // if pageX or pageY is defined we need to lock the popover to the given
+            // x and y position.
+            // clone the rect, so we can manipulate its properties.
+            var localRect = {
+              bottom: rect.bottom,
+              height: rect.height,
+              left: rect.left,
+              right: rect.right,
+              top: rect.top,
+              width: rect.width
             };
 
-            scope.$on('ns:popover:hide', function(ev, group) {
-              if (options.group === group) {
-                  scope.hidePopover();
-              }
-            });
-
-            $popover
-              .css('position', 'absolute')
-              .css('display', 'none');
-
-            //search for the triangle element - works in ie8+
-            $triangle = $popover[0].querySelectorAll('.triangle');
-            //if the element is found, then convert it to an angular element
-            if($triangle.length){
-              $triangle = $el($triangle);
+            if (adjustX) {
+              localRect.left = ev.pageX;
+              localRect.right = ev.pageX;
+              localRect.width = 0;
             }
 
-            $container.append($popover);
-          });
+            if (adjustY) {
+              localRect.top = ev.pageY;
+              localRect.bottom = ev.pageY;
+              localRect.height = 0;
+            }
 
-          if (options.angularEvent) {
-            $rootScope.$on(options.angularEvent, function() {
-              hider_.cancel();
-              displayer_.display(options.popupDelay);
-            });
-          } else if (options.scopeEvent) {
-            scope.$on(options.scopeEvent, function() {
-              hider_.cancel();
-              displayer_.display(options.popupDelay);
-            });
-          } else {
-            elm.on(options.trigger, function(e) {
-              if (false !== options.triggerPrevent) {
-                e.preventDefault();
-              }
-              hider_.cancel();
-              displayer_.display(options.popupDelay, e);
-            });
+            return localRect;
           }
 
-          elm
-            .on('mouseout', function() {
-              hider_.hide(options.timeout);
-            })
-            .on('mouseover', function() {
-              hider_.cancel();
-            });
+          function buttonClickHandler() {
+            if ($popover.isOpen) {
+              scope.hidePopover();
+            }
+          }
 
-          $popover
-            .on('mouseout', function(e) {
-              hider_.hide(options.timeout);
-            })
-            .on('mouseover', function() {
-              hider_.cancel();
-            });
+          function display(e) {
+            if (
+              angular.isObject(e) &&
+              false !== options.triggerPrevent
+            ) {
+              e.preventDefault();
+            }
+
+            hider_.cancel();
+            displayer_.display(options.popupDelay, e);
+          }
+
+          function getBoundingClientRect(elm) {
+            var w = window;
+            var doc = document.documentElement || document.body.parentNode || document.body;
+            var x = (isDef(w.pageXOffset)) ? w.pageXOffset : doc.scrollLeft;
+            var y = (isDef(w.pageYOffset)) ? w.pageYOffset : doc.scrollTop;
+            var rect = elm.getBoundingClientRect();
+
+            // ClientRect class is immutable, so we need to return a modified copy
+            // of it when the window has been scrolled.
+            if (x || y) {
+              return {
+                bottom:rect.bottom+y,
+                left:rect.left + x,
+                right:rect.right + x,
+                top:rect.top + y,
+                height:rect.height,
+                width:rect.width
+              };
+            }
+            return rect;
+          }
+
+          function insideClickHandler() {
+            if ($popover.isOpen) {
+              scope.hidePopover();
+            }
+          }
+
+          /**
+           * Load the given template in the cache if it is not already loaded.
+           *
+           * @param template The URI of the template to be loaded.
+           * @returns {String} A promise that the template will be loaded.
+           * @remarks If the template is null or undefined a empty string will be returned.
+           */
+          function loadTemplate(template, plain) {
+            if (!template) {
+              return '';
+            }
+
+            if (angular.isString(template) && plain) {
+              return template;
+            }
+
+            return $templateCache.get(template) || $http.get(template, { cache : true });
+          }
 
           /**
            * Move the popover to the |placement| position of the object located on the |rect|.
@@ -355,104 +308,7 @@
             }
           }
 
-          /**
-           * Adjust a rect accordingly to the given x and y mouse positions.
-           *
-           * @param rect {ClientRect} The rect to be adjusted.
-           */
-          function adjustRect(rect, adjustX, adjustY, ev) {
-            // if pageX or pageY is defined we need to lock the popover to the given
-            // x and y position.
-            // clone the rect, so we can manipulate its properties.
-            var localRect = {
-              bottom: rect.bottom,
-              height: rect.height,
-              left: rect.left,
-              right: rect.right,
-              top: rect.top,
-              width: rect.width
-            };
-
-            if (adjustX) {
-              localRect.left = ev.pageX;
-              localRect.right = ev.pageX;
-              localRect.width = 0;
-            }
-
-            if (adjustY) {
-              localRect.top = ev.pageY;
-              localRect.bottom = ev.pageY;
-              localRect.height = 0;
-            }
-
-            return localRect;
-          }
-
-          function getBoundingClientRect(elm) {
-            var w = window;
-            var doc = document.documentElement || document.body.parentNode || document.body;
-            var x = (isDef(w.pageXOffset)) ? w.pageXOffset : doc.scrollLeft;
-            var y = (isDef(w.pageYOffset)) ? w.pageYOffset : doc.scrollTop;
-            var rect = elm.getBoundingClientRect();
-
-            // ClientRect class is immutable, so we need to return a modified copy
-            // of it when the window has been scrolled.
-            if (x || y) {
-              return {
-                bottom:rect.bottom+y,
-                left:rect.left + x,
-                right:rect.right + x,
-                top:rect.top + y,
-                height:rect.height,
-                width:rect.width
-              };
-            }
-            return rect;
-          }
-
-          function toBoolean(value) {
-            if (value && value.length !== 0) {
-              var v = ("" + value).toLowerCase();
-              value = (v == 'true');
-            } else {
-              value = false;
-            }
-            return value;
-          }
-
-          /**
-           * Load the given template in the cache if it is not already loaded.
-           *
-           * @param template The URI of the template to be loaded.
-           * @returns {String} A promise that the template will be loaded.
-           * @remarks If the template is null or undefined a empty string will be returned.
-           */
-          function loadTemplate(template, plain) {
-            if (!template) {
-              return '';
-            }
-
-            if (angular.isString(template) && plain) {
-              return template;
-            }
-
-            return $templateCache.get(template) || $http.get(template, { cache : true });
-          }
-
-          function insideClickHandler() {
-            if ($popover.isOpen) {
-              hider_.hide(0);
-            }
-          }
-
           function outsideClickHandler(e) {
-            if ($popover.isOpen && e.target !== elm[0]) {
-              var id = $popover[0].id;
-              if (!isInPopover(e.target)) {
-                hider_.hide(0);
-              }
-            }
-
             function isInPopover(el) {
               if (el.id === id) {
                 return true;
@@ -471,13 +327,243 @@
                 return isInPopover(parent);
               }
             }
-          }
 
-          function buttonClickHandler() {
-            if ($popover.isOpen) {
-              hider_.hide(0);
+            if ($popover.isOpen && e.target !== elm[0]) {
+              var id = $popover[0].id;
+
+              if (!isInPopover(e.target)) {
+                scope.hidePopover();
+              }
             }
           }
+
+          function removeEventListeners() {
+            unregisterActivePopoverListeners();
+          }
+
+          function toBoolean(value) {
+            if (value && value.length !== 0) {
+              var v = ("" + value).toLowerCase();
+              value = (v == 'true');
+            } else {
+              value = false;
+            }
+            return value;
+          }
+
+          /**
+           * Responsible for displaying of popover.
+           * @type {Object}
+           */
+          displayer_ = {
+            id_: undefined,
+
+            /**
+             * Set the display property of the popover to 'block' after |delay| milliseconds.
+             *
+             * @param delay {Number}  The time (in seconds) to wait before set the display property.
+             * @param e {Event}  The event which caused the popover to be shown.
+             */
+            display: function(delay, e) {
+              // Disable popover if ns-popover value is false
+              if ($parse(attrs.nsPopover)(scope) === false) {
+                return;
+              }
+
+              $timeout.cancel(displayer_.id_);
+
+              if (!isDef(delay)) {
+                delay = 0;
+              }
+
+              // hide any popovers being displayed
+              if (options.group) {
+                $rootScope.$broadcast('ns:popover:hide', options.group);
+              }
+
+              displayer_.id_ = $timeout(function() {
+                $popover.isOpen = true;
+                $popover.css('display', 'block');
+
+                // position the popover accordingly to the defined placement around the
+                // |elm|.
+                var elmRect = getBoundingClientRect(elm[0]);
+
+                // If the mouse-relative options is specified we need to adjust the
+                // element client rect to the current mouse coordinates.
+                if (options.mouseRelative) {
+                  elmRect = adjustRect(elmRect, options.mouseRelativeX, options.mouseRelativeY, e);
+                }
+
+                move($popover, placement_, align_, elmRect, $triangle);
+                addEventListeners();
+
+                // Hide the popover without delay on the popover click events.
+                if (true === options.hideOnInsideClick) {
+                  $popover.on('click', insideClickHandler);
+                }
+
+                // Hide the popover without delay on outside click events.
+                if (true === options.hideOnOutsideClick) {
+                  $document.on('click', outsideClickHandler);
+                }
+
+                // Hide the popover without delay on the button click events.
+                if (true === options.hideOnButtonClick) {
+                  elm.on('click', buttonClickHandler);
+                }
+              }, delay*1000);
+            },
+
+            cancel: function() {
+              $timeout.cancel(displayer_.id_);
+            }
+          };
+
+          /**
+           * Responsible for hiding of popover.
+           * @type {Object}
+           */
+          hider_ = {
+            id_: undefined,
+
+            /**
+             * Set the display property of the popover to 'none' after |delay| milliseconds.
+             *
+             * @param delay {Number}  The time (in seconds) to wait before set the display property.
+             */
+            hide: function(delay) {
+              $timeout.cancel(hider_.id_);
+
+              // do not hide if -1 is passed in.
+              if(delay !== "-1") {
+                // delay the hiding operation for 1.5s by default.
+                if (!isDef(delay)) {
+                  delay = 1.5;
+                }
+
+                hider_.id_ = $timeout(function() {
+                  $popover.off('click', insideClickHandler);
+                  $document.off('click', outsideClickHandler);
+                  elm.off('click', buttonClickHandler);
+                  $popover.isOpen = false;
+                  displayer_.cancel();
+                  $popover.css('display', 'none');
+                  removeEventListeners();
+                }, delay*1000);
+              }
+            },
+
+            cancel: function() {
+              $timeout.cancel(hider_.id_);
+            }
+          };
+
+          // Set the container to the passed selector. If the container element
+          // was not found, use the body as the container.
+          $container = $document.find(options.container);
+          if (!$container.length) {
+            $container = $document.find('body');
+          }
+
+          // Parse the desired placement and alignment values.
+          match = options
+            .placement
+            .match(/^(top|bottom|left|right)$|((top|bottom)\|(center|left|right)+)|((left|right)\|(center|top|bottom)+)/)
+          ;
+          if (!match) {
+            throw new Error(
+              '"' + options.placement + '" is not a valid placement or has ' +
+              'an invalid combination of placements.'
+            );
+          }
+          placement_ = match[6] || match[3] || match[1];
+          align_ = match[7] || match[4] || match[2] || 'center';
+
+          // Create the popover element and add it to the cached list of all
+          // popovers.
+          globalId += 1;
+          $popover = $el('<div id="nspopover-' + globalId +'"></div>')
+            .addClass('ns-popover-' + placement_ + '-placement')
+            .addClass('ns-popover-' + align_ + '-align')
+            .css('position', 'absolute')
+            .css('display', 'none')
+          ;
+          $popovers.push($popover);
+
+          // Allow closing the popover programatically.
+          scope.hidePopover = function() {
+            hider_.hide(0);
+          };
+
+          // Hide popovers that are associated with the passed group.
+          scope.$on('ns:popover:hide', function(ev, group) {
+            if (options.group === group) {
+                scope.hidePopover();
+            }
+          });
+
+          // Clean up after yourself.
+          scope.$on('$destroy', function() {
+            $popover.remove();
+            unregisterDisplayMethod();
+          });
+
+          // Display the popover when a message is broadcasted on the
+          // $rootScope if `angular-event` was given.
+          if (angular.isString(options.angularEvent)) {
+            unregisterDisplayMethod = $rootScope.$on(
+              options.angularEvent,
+              display
+            );
+
+          // Display the popover when a message is broadcasted on the
+          // scope if `scope-event` was given.
+          } else if (angular.isString(options.scopeEvent)) {
+            unregisterDisplayMethod = scope.$on(
+              options.scopeEvent,
+              display
+            )
+
+          // Otherwise just display the popover whenever the event that was
+          // passed to the `trigger` attribute occurs on the element.
+          } else {
+            elm.on(options.trigger, display);
+            unregisterDisplayMethod = function() {
+              elm.off(options.trigger, display);
+            }
+          }
+
+          // Load the template and compile the popover.
+          $q
+            .when(loadTemplate(options.template, options.plain))
+            .then(function(template) {
+              if (angular.isObject(template)) {
+                template = angular.isString(template.data) ?
+                  template.data : ''
+                ;
+              }
+
+              // Set the popover element HTML.
+              $popover.html(template);
+
+              // Add the "theme" class to the element.
+              if (options.theme) {
+                $popover.addClass(options.theme);
+              }
+
+              // Compile the element.
+              $compile($popover)(scope);
+
+              // Cache the triangle element (works in ie8+).
+              $triangle = $el(
+                $popover[0].querySelectorAll('.triangle')
+              );
+
+              // Append it to the DOM
+              $container.append($popover);
+            })
+          ;
         }
       };
     }


### PR DESCRIPTION
While working on adding some features to this repository, I found that the code wasn't very well organized in all places and it was very difficult to read at times.

While this PR appears to be rather large, it's mostly just moving things around and not changing much of the syntax (while some things have changed slightly).

1. Move all variable declarations to the top of the scoped method, in this case, the `link` function.
2. Move all anonymous functions to the top of the scoped method, so that they are defined before being called.
3. Sort any list of variables and/or functions in alphabetical order.
4. Use strict comparisons rather than loose `truthy` or `falsey` style, e.g. `(true === options.hideOnInsideClick)`.
5. More comments.

While reorganizing, I also took the opportunity to be more mindful of event binding. For example, [this block of code](https://github.com/gabehayes/nsPopover/blob/1b66569398f66159fc0377ae5b1e9ca05045324e/src/nsPopover.js#L512-L535) caches the unregister method of `scope.$on` or `$rootScope.$on`, and calls it during a `$destroy` so we can make sure this component is cleaning up after itself.

Also, prior to this update, the `mouseover` and `mouseout` events were being bound to both the `$popover` and `elm`, regardless of popover state. So, even though there was no popover being shown, there were 4 events bound to the popover target element.

I have updated it so that when you display a popover, we add the respective `mouseover` and `mouseout` events, and when that popover is hidden, we remove them.

This ensures that the 4 `mouseover` and `mouseout` events are only active and executing during the period of time that the popover is being displayed. I don't think this would make a huge difference in performance, but I think cleaning up after yourself like this is a better practice.

Again, the size of the PR itself may be misleading as most of this code is just being moved around and not actually being changed very much.