### PR TITLE
Add callbacks for when a popover is opened or closed.

### DIFF
--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -15,6 +15,8 @@
       hideOnInsideClick: false,
       hideOnOutsideClick: true,
       mouseRelative: '',
+      onClose: angular.noop,
+      onOpen: angular.noop,
       placement: 'bottom|left',
       plain: 'false',
       popupDelay: 0,
@@ -81,6 +83,8 @@
             hideOnInsideClick: toBoolean(attrs.nsPopoverHideOnInsideClick || defaults.hideOnInsideClick),
             hideOnOutsideClick: toBoolean(attrs.nsPopoverHideOnOutsideClick || defaults.hideOnOutsideClick),
             mouseRelative: attrs.nsPopoverMouseRelative,
+            onClose: $parse(attrs.nsPopoverOnClose) || defaults.onClose,
+            onOpen: $parse(attrs.nsPopoverOnOpen) || defaults.onOpen,
             placement: attrs.nsPopoverPlacement || defaults.placement,
             plain: toBoolean(attrs.nsPopoverPlain || defaults.plain),
             popupDelay: attrs.nsPopoverPopupDelay || defaults.popupDelay,
@@ -416,6 +420,9 @@
                 if (true === options.hideOnButtonClick) {
                   elm.on('click', buttonClickHandler);
                 }
+
+                // Call the open callback
+                options.onOpen(scope);
               }, delay*1000);
             },
 
@@ -454,6 +461,9 @@
                   displayer_.cancel();
                   $popover.css('display', 'none');
                   removeEventListeners();
+
+                  // Call the close callback
+                  options.onClose(scope);
                 }, delay*1000);
               }
             },

--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -382,6 +382,10 @@
               }
 
               displayer_.id_ = $timeout(function() {
+                if (true === $popover.isOpen) {
+                  return;
+                }
+
                 $popover.isOpen = true;
                 $popover.css('display', 'block');
 


### PR DESCRIPTION
Currently, it appears that there are two ways to hook into the _opening_ of a popover.

1. Use the `ns-popover-angular-event`, which will open the popover when the given event name is broadcasted on the `$rootScope`. You can listen to that event elsewhere and know that when it is called, the popover was also told to display.

2. Use the `ns-popover-scope-event`, which will open the popover when the given event name is broadcasted on the `$scope`. As with `angular-event`, you can listen for that event and respond accordingly.

The problem with the two approaches above is that sometimes there are _many_ popovers on the same scope, so unless you are using group ids, you may be triggering numerous popovers to display when you had only wanted to open one.

To remedy this, both `ns-popover-angular-event` and `ns-popover-scope-event` should parse the passed in values, so that you could bind to an event such as `some:event:{{ some.id }}`.

I found that this was a level of complexity that was beyond what I was looking to do.

Really, I just wanted to run callback methods when the associated popover was either opened or closed.

These proposed changes introduce the following attributes:

```
<div ns-popover
     ns-popover-on-open="onPopoverOpen()"
     ns-popover-on-close="onPopoverClose()"
></div>
```

The callbacks will be executed when the respective popover's `displayer_.display` or `hider_.hide` methods are called.