### PR TITLE
Fixed huge memory leak issue with $popovers

### DIFF
--- a/src/nsPopover.js
+++ b/src/nsPopover.js
@@ -2,7 +2,6 @@
   'use strict';
 
   var $el = angular.element;
-  var $popovers = [];
   var globalId = 0;
   var isDef = angular.isDefined;
   var module = angular.module('nsPopover', []);
@@ -503,7 +502,6 @@
             .css('position', 'absolute')
             .css('display', 'none')
           ;
-          $popovers.push($popover);
 
           // Allow closing the popover programatically.
           scope.hidePopover = function() {


### PR DESCRIPTION
The $popovers array defined outside of the directive, was never cleared when popovers are removed from the DOM. 

This causes a huge memory leak in large lists which greatly slows down the application. Since $popovers is actually never used - I removed it entirely. No more memory leaks!